### PR TITLE
Added documentation section explaining that nodes will still be prese…

### DIFF
--- a/doc_source/opscm-disassociate-node.md
+++ b/doc_source/opscm-disassociate-node.md
@@ -20,6 +20,8 @@ We recommend that you disassociate nodes from a Chef server before you delete th
 
 1. Wait until a response message indicates that the disassociation is finished\.
 
+When a node is successfully disassociated from the AWS OpsWorks for Chef Automate server, it may still be visible in the Chef Automate dashboard\. By default a retention period for node state information is enforced, and the node will automatically be purged after a few days\. For more information, please refer to Chef's [Data Retention Management Documentation](https://docs.chef.io/data_retention_chef_automate.html)\.
+
 For more information about how to delete an AWS OpsWorks for Chef Automate server, see \.
 
 ## Related Topics<a name="opscm-disassoc-related"></a>

--- a/doc_source/opscm-disassociate-node.md
+++ b/doc_source/opscm-disassociate-node.md
@@ -20,7 +20,7 @@ We recommend that you disassociate nodes from a Chef server before you delete th
 
 1. Wait until a response message indicates that the disassociation is finished\.
 
-When a node is successfully disassociated from the AWS OpsWorks for Chef Automate server, it may still be visible in the Chef Automate dashboard\. By default a retention period for node state information is enforced, and the node will automatically be purged after a few days\. For more information, please refer to Chef's [Data Retention Management Documentation](https://docs.chef.io/data_retention_chef_automate.html)\.
+After you successfully disassociate a node from a AWS OpsWorks for Chef Automate server, it might still be visible in the Chef Automate dashboard\. By default, Chef enforces a retention period for node state information, and purges the node automatically after a few days\. For more information about data retention management and the Chef Reaper tool, see [Data Retention Management](https://docs.chef.io/data_retention_chef_automate.html) in the Chef documentation\.
 
 For more information about how to delete an AWS OpsWorks for Chef Automate server, see \.
 


### PR DESCRIPTION
…nt in the Chef Automate dashboard until the configured retention period passes.

*Issue #, if available:* N/A

*Description of changes:* Added a section to explain that nodes are still present in the Chef Automate dashboard, even after calling DisassociateNode, as this is based off Chef Automate's reaper settings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
