### PR TITLE
Correct IAM role and CF stack URL for automatic node association to Chef Automate

### DIFF
--- a/doc_source/opscm-unattend-assoc.md
+++ b/doc_source/opscm-unattend-assoc.md
@@ -27,9 +27,7 @@ Create an AWS Identity and Access Management \(IAM\) role to use as your EC2 ins
         {
             "Action": [
                 "opsworks-cm:AssociateNode",
-                "opsworks-cm:DescribeNodeAssociationStatus",
-                "opsworks-cm:DescribeServers",
-                "ec2:DescribeTags"
+                "opsworks-cm:DescribeNodeAssociationStatus"
             ],
             "Resource": "*",
             "Effect": "Allow"
@@ -41,7 +39,7 @@ Create an AWS Identity and Access Management \(IAM\) role to use as your EC2 ins
 AWS OpsWorks provides an AWS CloudFormation template that you can use to create the IAM role with the preceding policy statement\. The following AWS CLI command creates the instance profile role for you by using this template\. You can omit the `--region` parameter if you want to create the new AWS CloudFormation stack in your default region\.
 
 ```
-aws cloudformation --region region ID create-stack --stack-name myChefAutomateinstanceprofile --template-url https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/owpe/opsworks-cm-nodes-roles.yaml --capabilities CAPABILITY_IAM
+aws cloudformation --region region ID create-stack --stack-name myChefAutomateinstanceprofile --template-url https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/opsworks-cm-nodes-roles.yaml --capabilities CAPABILITY_IAM
 ```
 
 ## Step 2: Install the Chef Client Cookbook<a name="w3ab2b9c27c17"></a>


### PR DESCRIPTION
This is a discrepancy between the OpsWorks Chef Automate starter kit README which includes following CF stack for creating the IAM role for automatic node association:
```
https://s3.amazonaws.com/opsworks-cm-us-east-1-prod-default-assets/misc/opsworks-cm-nodes-roles.yaml
```

The IAM role included is:
```
AWSTemplateFormatVersion: '2010-09-09'
Description: AWS OpsWorks for Chef Automate - IAM Resource for nodes
<snip>
          Statement:
          - Action:
            - opsworks-cm:AssociateNode
            - opsworks-cm:DescribeNodeAssociationStatus
            Effect: Allow
            Resource: '*'
...
```

The currently specified stack `misc/owpe/opsworks-cm-nodes-roles.yaml` includes additional actions not required and has the description: 

> "AWS OpsWorks for Puppet Enterprise - IAM resource for nodes"

which leads to some confusion for a customer setting up Chef Automate.