### PR TITLE
editing service role ARN

### DIFF
--- a/doc_source/gettingstarted-opscm-create.md
+++ b/doc_source/gettingstarted-opscm-create.md
@@ -143,7 +143,7 @@ If your local computer is not already running the AWS CLI, download and install 
    The following is an example\.
 
    ```
-   aws opsworks-cm create-server --engine "Chef" --engine-model "Single" --engine-version "12" --server-name "automate-06" --instance-profile-arn "arn:aws:iam::1019881987024:instance-profile/aws-opsworks-cm-ec2-role" --instance-type "m4.large" --engine-attributes '{"CHEF_PIVOTAL_KEY":"MZZE...Wobg","CHEF_DELIVERY_ADMIN_PASSWORD":"zZZzDj2DLYXSZFRv1d"}' --key-pair "amazon-test" --preferred-maintenance-window "Mon:08:00" --preferred-backup-window "Sun:02:00" --security-group-ids sg-b00000001 sg-b0000008 --service-role-arn "arn:aws:iam::044726508045:role/aws-opsworks-cm-service-role" --subnet-ids subnet-300aaa00
+   aws opsworks-cm create-server --engine "Chef" --engine-model "Single" --engine-version "12" --server-name "automate-06" --instance-profile-arn "arn:aws:iam::1019881987024:instance-profile/aws-opsworks-cm-ec2-role" --instance-type "m4.large" --engine-attributes '{"CHEF_PIVOTAL_KEY":"MZZE...Wobg","CHEF_DELIVERY_ADMIN_PASSWORD":"zZZzDj2DLYXSZFRv1d"}' --key-pair "amazon-test" --preferred-maintenance-window "Mon:08:00" --preferred-backup-window "Sun:02:00" --security-group-ids sg-b00000001 sg-b0000008 --service-role-arn "arn:aws:iam::044726508045:role/service-role/aws-opsworks-cm-service-role" --subnet-ids subnet-300aaa00
    ```
 
 1. AWS OpsWorks for Chef Automate takes about 15 minutes to create a new server\. Do not dismiss the output of the `create-server` command or close your shell session, because the output can contain important information that is not shown again\. To get passwords and the starter kit from the `create-server` results, go on to the next step\.


### PR DESCRIPTION
Service role ARN should be format:

Note the difference:

arn:aws:iam::044726508045:role/service-role/aws-opsworks-cm-service-role
NOT
arn:aws:iam::044726508045:role/aws-opsworks-cm-service-role

Otherwise, this will cause error: "Service: AWSSecurityTokenService; Status Code: 403; Error Code: AccessDenied; Request ID:" because iam:PassRole is only allowed for the first of the two, based on the default policy created by the service role

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
