### PR TITLE
Use aws-sdk-s3 gem not aws-sdk

### DIFF
--- a/doc_source/cookbooks-101-opsworks-s3-windows.md
+++ b/doc_source/cookbooks-101-opsworks-s3-windows.md
@@ -40,14 +40,14 @@ The procedure for setting up the cookbook is similar to the one used by [Running
    ```
    Chef::Log.info("******Downloading an object from S3******")
    
-   chef_gem "aws-sdk" do
+   chef_gem "aws-sdk-s3" do
      compile_time false
      action :install
    end
    
    ruby_block "download-object" do
      block do
-       require 'aws-sdk'
+       require 'aws-sdk-s3'
        
        Aws.use_bundled_cert!
    

--- a/doc_source/gettingstarted-windows-deploy.md
+++ b/doc_source/gettingstarted-windows-deploy.md
@@ -52,14 +52,14 @@ You typically download the application by using a repository's public API\. This
 Add a recipe named `deploy.rb` to the `iis-cookbook` `recipes` directory, with the following contents\.
 
 ```
-chef_gem "aws-sdk" do
+chef_gem "aws-sdk-s3" do
   compile_time false
   action :install
 end
 
 ruby_block "download-object" do
   block do
-    require 'aws-sdk'
+    require 'aws-sdk-s3'
 
     #1  
     # Aws.config[:ssl_ca_bundle] = 'C:\ProgramData\Git\bin\curl-ca-bundle.crt'


### PR DESCRIPTION
This fixes an issue where gem gets into a loop installing aws-sdk and
never completes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
