### PR TITLE
Corrected openssl command to generate public key

### DIFF
--- a/doc_source/opscm-create-server-cfn.md
+++ b/doc_source/opscm-create-server-cfn.md
@@ -30,7 +30,7 @@ Generate a base64\-encoded RSA key pair before you get started creating a Chef A
   Then, export the RSA public key portion of the pair to a file\. The public key becomes the value of `CHEF_AUTOMATE_PIVOTAL_KEY`\.
 
   ```
-  openssl rsa -in pivotal_key_file_name.pem -out public.pem -outform PEM
+  openssl rsa -in pivotal_key_file_name.pem -pubout -out public.pem -outform PEM
   ```
 + On Windows\-based computers, you can use the PuTTYgen utility to generate a base64\-encoded RSA key pair\. For more information, see [PuTTYgen \- Key Generator for PuTTY on Windows](https://www.ssh.com/ssh/putty/windows/puttygen) on SSH\.com\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
openssl command used to generate public key was incorrect, added -pubout option to correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
